### PR TITLE
chore: update to Python 3.13 and move to `uv`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-FROM python:3.9.20-bookworm
-RUN apt-get update && apt-get install -y gcc g++ make curl zlib1g-dev libjpeg-dev libxml2-dev libxslt-dev libfreetype6-dev libmupdf-dev tzdata
-ENV C_INCLUDE_PATH $C_INCLUDE_PATH:/usr/include/freetype2
-RUN python -m pip install --upgrade pip
-RUN pip install poetry==1.4.1
-ENV PATH /root/.poetry/bin:$PATH
-RUN poetry config virtualenvs.create false && \
-    poetry config virtualenvs.in-project false && \
-    poetry config installer.modern-installation false
+FROM python:3.13-slim-bookworm
+RUN apt-get update && apt-get install -y gcc g++ make curl zlib1g-dev libjpeg-dev libxml2-dev libxslt-dev libfreetype6-dev libmupdf-dev tzdata vim-tiny && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/vim.tiny /usr/local/bin/vi \
+    && ln -s /usr/bin/vim.tiny /usr/local/bin/vim
+ENV C_INCLUDE_PATH=/usr/include/freetype2
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+ENV UV_SYSTEM_PYTHON=1
 WORKDIR /app
 COPY entry.sh /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/entry.sh"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Poetry on Python
+# Python with uv
 
-This repository provides a pre-installed version of Poetry, on top of Python, for development and CI use.
+This repository provides a pre-installed version of [uv](https://docs.astral.sh/uv/), on top of Python 3.13, for development and CI use.
 
 ## Usage
-In your project, just start `FROM vitalbeats/poetry:1.1.x`.
+In your project, just start `FROM vitalbeats/python:1.x.x`.
 
 ## Building and Pushing
 
@@ -11,18 +11,20 @@ We build the image locally and push it to Docker Hub.
 
 Note: The user must be logged in into our public docker registry via `docker login`.
 
-```bash
-docker build . --platform=linux/amd64 --tag=vitalbeats/poetry:1.1.13
-docker push vitalbeats/poetry:1.1.13
+We always build for `linux/amd64` because our target environments (dev, QA, and production) are x86-based.
 
-docker build . --platform=linux/amd64 --tag=vitalbeats/poetry:latest
-docker push vitalbeats/poetry:latest
+```bash
+docker build . --platform=linux/amd64 --tag=vitalbeats/python:1.x.x
+docker push vitalbeats/python:1.x.x
+
+docker build . --platform=linux/amd64 --tag=vitalbeats/python:latest
+docker push vitalbeats/python:latest
 ```
 ## Running Locally
 ```bash
 docker run \
     --platform=linux/amd64 \
-    --name vb_poetry \
-    -it --rm poetry:1.1.13 \
+    --name vb_python \
+    -it --rm vitalbeats/python:1.x.x \
     --version
 ```

--- a/entry.sh
+++ b/entry.sh
@@ -4,4 +4,4 @@ if [ "${TZ}x" = "x" ]; then
 	export TZ=UTC
 fi
 export TZ="${TZ}"
-poetry $@
+uv $@


### PR DESCRIPTION
We've decided to retire Poetry in Vitalbeats and instead use `uv` package manager.

Ref: https://linear.app/vitalbeats/issue/VB-2922/move-python-projects-to-newer-python-version